### PR TITLE
Add diagnostic and visualization feedback options to self-refinement

### DIFF
--- a/src/ale_bench_eval/__main__.py
+++ b/src/ale_bench_eval/__main__.py
@@ -74,6 +74,9 @@ def evaluate_contest(
     root_path: Path | None = None,
     llm_semaphore: BoundedSemaphore | None = None,
     max_repeated_sampling_workers: int | None = None,
+    feedback_diagnostic: bool = False,
+    feedback_visualization: bool = False,
+    n_feedback_worst_cases: int = 3,
 ) -> None:
     """Main evaluation function orchestrating the entire benchmarking process."""
     start_time = get_now_utc()
@@ -90,6 +93,9 @@ def evaluate_contest(
         problem_id=problem_id,
         lite_version=lite_version,
         root_path=root_path,
+        feedback_diagnostic=feedback_diagnostic,
+        feedback_visualization=feedback_visualization,
+        n_feedback_worst_cases=n_feedback_worst_cases,
     )
 
     # Initialize session and logging
@@ -257,6 +263,9 @@ def _run_evaluation_task(
     root_path: Path,
     llm_semaphore: BoundedSemaphore | None,
     max_repeated_sampling_workers: int | None,
+    feedback_diagnostic: bool,
+    feedback_visualization: bool,
+    n_feedback_worst_cases: int,
 ) -> tuple[str, bool, str]:
     """Wrapper function for parallel evaluation execution."""
     try:
@@ -276,6 +285,9 @@ def _run_evaluation_task(
             root_path=root_path,
             llm_semaphore=llm_semaphore,
             max_repeated_sampling_workers=max_repeated_sampling_workers,
+            feedback_diagnostic=feedback_diagnostic,
+            feedback_visualization=feedback_visualization,
+            n_feedback_worst_cases=n_feedback_worst_cases,
         )
         print(f"✅ Completed: {model_name} on {problem_id}")
     except Exception as e:
@@ -304,6 +316,9 @@ def main(
     use_statement_image: bool = False,
     root_path: str | None = None,
     skip_llm_inference: bool = False,
+    feedback_diagnostic: bool = False,
+    feedback_visualization: bool = False,
+    n_feedback_worst_cases: int = 3,
 ) -> None:
     """Main entry point for running LLM benchmarking evaluation."""
     start_time = get_now_utc()
@@ -410,6 +425,15 @@ def main(
         if existing_settings["selection_method"] != selection_method:
             msg = "Experiment settings already exist with different selection_method"
             raise ValueError(msg)
+        if existing_settings.get("feedback_diagnostic", False) != feedback_diagnostic:
+            msg = "Experiment settings already exist with different feedback_diagnostic"
+            raise ValueError(msg)
+        if existing_settings.get("feedback_visualization", False) != feedback_visualization:
+            msg = "Experiment settings already exist with different feedback_visualization"
+            raise ValueError(msg)
+        if existing_settings.get("n_feedback_worst_cases", 3) != n_feedback_worst_cases:
+            msg = "Experiment settings already exist with different n_feedback_worst_cases"
+            raise ValueError(msg)
     # Save (update) experiment settings
     with setting_path.open("w") as f:
         json.dump(
@@ -429,6 +453,9 @@ def main(
                 "max_repeated_sampling_workers": max_repeated_sampling_workers,
                 "problem_ids_type": problem_ids_type,
                 "selection_method": selection_method,
+                "feedback_diagnostic": feedback_diagnostic,
+                "feedback_visualization": feedback_visualization,
+                "n_feedback_worst_cases": n_feedback_worst_cases,
             },
             f,
             indent=4,
@@ -475,6 +502,9 @@ def main(
                     exp_root,
                     llm_semaphore,
                     max_repeated_sampling_workers,
+                    feedback_diagnostic,
+                    feedback_visualization,
+                    n_feedback_worst_cases,
                 ): problem_id
                 for problem_id in problem_ids
             }

--- a/src/ale_bench_eval/data_types.py
+++ b/src/ale_bench_eval/data_types.py
@@ -27,3 +27,6 @@ class EvaluationConfig:
     problem_id: str
     lite_version: bool
     root_path: Path | None = None
+    feedback_diagnostic: bool = False
+    feedback_visualization: bool = False
+    n_feedback_worst_cases: int = 3

--- a/src/ale_bench_eval/prompts/builder.py
+++ b/src/ale_bench_eval/prompts/builder.py
@@ -13,6 +13,7 @@ from ale_bench_eval.prompts.texts import (
     CODE_BLOCK_MATCH,
     CODE_BLOCK_STRING,
     CONSIDERATION_PROMPT,
+    DIAGNOSTIC_FEEDBACK_PROMPT,
     FEEDBACK_PROMPT,
     IMPLEMENTATION_ANY_PROMPT,
     IMPLEMENTATION_SPECIFIC_PROMPT,
@@ -22,6 +23,7 @@ from ale_bench_eval.prompts.texts import (
     REFINE_ANY_PROMPT,
     REFINE_SPECIFIC_PROMPT,
     SYSTEM_PROMPT,
+    VIS_FEEDBACK_PROMPT,
     get_code_block_string_any,
     get_code_language_libraries,
     get_code_language_libraries_any,
@@ -158,21 +160,45 @@ def result_feedback(args: PromptArgs, result: Result | None) -> str:
     return feedback
 
 
-def create_feedback_message(args: PromptArgs, public_result: Result | None) -> list[str]:
+def diagnostic_feedback(args: PromptArgs, result: Result, worst_indices: list[int]) -> str:
+    worst_set = set(worst_indices)
+    case_lines = []
+    for idx, case_result in enumerate(result.case_results):
+        params = case_result.input_str.split("\n", 1)[0].strip() if case_result.input_str else "N/A"
+        line = f'- Case {idx + 1}: params="{params}", score={case_result.absolute_score}'
+        if case_result.judge_result != JudgeResult.ACCEPTED:
+            line += f", judge={case_result.judge_result.value}"
+        if idx in worst_set:
+            line += " (WORST)"
+        case_lines.append(line)
+    return DIAGNOSTIC_FEEDBACK_PROMPT[args.prompt_language].substitute(case_table="\n".join(case_lines))
+
+
+def create_feedback_message(
+    args: PromptArgs,
+    public_result: Result | None,
+    *,
+    diagnostic: str | None = None,
+    visualizations: list[BinaryContent] | None = None,
+    visualized_case_indices: list[int] | None = None,
+) -> list[str | BinaryContent]:
     feedback = result_feedback(args, public_result)
+    if diagnostic is not None:
+        feedback += diagnostic
     if args.code_language == "any":
-        return [
-            FEEDBACK_PROMPT[args.prompt_language].substitute(feedback=feedback)
-            + REFINE_ANY_PROMPT[args.prompt_language].substitute(
-                code_blocks=get_code_block_string_any(args.judge_version),
-            )
-        ]
-    return [
-        FEEDBACK_PROMPT[args.prompt_language].substitute(feedback=feedback)
-        + REFINE_SPECIFIC_PROMPT[args.prompt_language].substitute(
+        refine_prompt = REFINE_ANY_PROMPT[args.prompt_language].substitute(
+            code_blocks=get_code_block_string_any(args.judge_version),
+        )
+    else:
+        refine_prompt = REFINE_SPECIFIC_PROMPT[args.prompt_language].substitute(
             code_block=CODE_BLOCK_STRING[args.code_language],
         )
-    ]
+    feedback_prompt = FEEDBACK_PROMPT[args.prompt_language].substitute(feedback=feedback)
+    if not visualizations:
+        return [feedback_prompt + refine_prompt]
+    case_indices = ", ".join(str(idx + 1) for idx in visualized_case_indices or [])
+    feedback_prompt += VIS_FEEDBACK_PROMPT[args.prompt_language].substitute(case_indices=case_indices)
+    return [feedback_prompt, *visualizations, refine_prompt]
 
 
 def get_code_from_response(response: str, code_language: str, judge_version: str) -> tuple[str, str]:

--- a/src/ale_bench_eval/prompts/texts.py
+++ b/src/ale_bench_eval/prompts/texts.py
@@ -681,6 +681,36 @@ FEEDBACK_PROMPT_WITH_SUMMARY = {
         "単純なバグ修正、新しいアルゴリズムの導入、または小さな変更から大きな変更まで、どの程度の変更でも構いません。"
     ),
 }
+DIAGNOSTIC_FEEDBACK_PROMPT = {
+    "en": Template(
+        "\n\n[Per-case diagnostics]\n"
+        "Each public case is listed with its instance parameters (the first line of its input) and its score. "
+        "The worst-scoring cases are marked with (WORST).\n"
+        "${case_table}\n"
+        "Before refining your code, state a hypothesis about which input regimes "
+        "(e.g. parameter ranges) your solution handles poorly and why. "
+    ),
+    "ja": Template(
+        "\n\n[ケースごとの診断]\n"
+        "各パブリックケースについて、インスタンスパラメータ(入力の1行目)とスコアを列挙します。"
+        "スコアが最も悪いケースには (WORST) が付いています。\n"
+        "${case_table}\n"
+        "コードを改良する前に、あなたの解法がどのような入力領域(パラメータ範囲など)で"
+        "性能が悪いのか、そしてその理由について仮説を述べてください。"
+    ),
+}
+VIS_FEEDBACK_PROMPT = {
+    "en": Template(
+        "\n\nThe images below visualize the final state of your solution "
+        "on the worst-scoring cases: ${case_indices}. "
+        "Inspect them for structural weaknesses before refining your code.\n"
+    ),
+    "ja": Template(
+        "\n\n以下の画像は、スコアが最も悪いケース(${case_indices})における"
+        "あなたの解法の最終状態を可視化したものです。"
+        "コードを改良する前に、構造的な弱点がないか確認してください。\n"
+    ),
+}
 REFINE_ANY_PROMPT = {
     "en": Template(
         "Your solution code should be written in the specified code block as follows:\n${code_blocks}"

--- a/src/ale_bench_eval/scaffolds.py
+++ b/src/ale_bench_eval/scaffolds.py
@@ -4,9 +4,11 @@ from threading import BoundedSemaphore
 from time import sleep
 from typing import Any, TypeVar
 
+from pydantic_ai import BinaryContent
 from pydantic_ai.messages import ModelMessage, UserContent
 from pydantic_ai.run import AgentRunResult
 
+from ale_bench.constants import NO_LOCAL_VIS
 from ale_bench.result import JudgeResult, Result
 from ale_bench.session import Session
 from ale_bench_eval.calc_cost import calc_cost
@@ -15,11 +17,13 @@ from ale_bench_eval.evaluate import get_ce_code
 from ale_bench_eval.language_config import get_default_code_language
 from ale_bench_eval.logger import SaveInfo
 from ale_bench_eval.prompts.builder import (
+    convert_pillow_to_binary,
     create_feedback_message,
+    diagnostic_feedback,
     get_code_from_response,
 )
 from ale_bench_eval.safe_generation import MaxTokenError, safe_generation
-from ale_bench_eval.selection import get_worst_score
+from ale_bench_eval.selection import get_worst_score, select_worst_case_indices
 
 TIMEOUT_SECONDS = 3600
 MAX_RETRIES = 30
@@ -114,6 +118,77 @@ def _evaluate_and_save_public_result(
         lambda: save_info.save_ale_bench_results(filename, public_result),
     )
     return public_result
+
+
+def _render_worst_case_visualizations(
+    session: Session,
+    public_result: Result,
+    worst_indices: list[int],
+    save_info: SaveInfo,
+) -> tuple[list[BinaryContent], list[int]]:
+    """Render visualization images of the worst cases; failures degrade to no images."""
+    if session.problem.metadata.problem_id in NO_LOCAL_VIS:
+        return [], []
+    candidate_indices: list[int] = []
+    input_strs: list[str] = []
+    output_strs: list[str] = []
+    for idx in worst_indices:
+        case_result = public_result.case_results[idx]
+        if case_result.input_str is None or case_result.output_str is None:
+            continue
+        candidate_indices.append(idx)
+        input_strs.append(case_result.input_str)
+        output_strs.append(case_result.output_str)
+    if not candidate_indices:
+        return [], []
+    try:
+        images = session.local_visualization(input_strs, output_strs)
+    except Exception as e:
+        save_info.logger.info("Local visualization failed: %s", e)
+        return [], []
+    if not isinstance(images, list):  # scalar result for a single case
+        images = [images]
+    rendered_indices: list[int] = []
+    rendered_images = []
+    for idx, image in zip(candidate_indices, images, strict=True):
+        if image is not None:
+            rendered_indices.append(idx)
+            rendered_images.append(image)
+    binary_contents = [
+        content for content in convert_pillow_to_binary(rendered_images, "png") if isinstance(content, BinaryContent)
+    ]
+    return binary_contents, rendered_indices
+
+
+def _build_refinement_user_prompt(
+    config: EvaluationConfig,
+    session: Session,
+    public_result: Result | None,
+    save_info: SaveInfo,
+) -> list[str | BinaryContent]:
+    if public_result is None or not (config.feedback_diagnostic or config.feedback_visualization):
+        return create_feedback_message(config.prompt_args, public_result)
+    worst_indices = select_worst_case_indices(
+        public_result.case_results,
+        session.problem.metadata.score_type,
+        config.n_feedback_worst_cases,
+    )
+    diagnostic = None
+    if config.feedback_diagnostic:
+        diagnostic = diagnostic_feedback(config.prompt_args, public_result, worst_indices)
+    visualizations: list[BinaryContent] = []
+    rendered_indices: list[int] = []
+    if config.feedback_visualization:
+        visualizations, rendered_indices = _render_worst_case_visualizations(
+            session, public_result, worst_indices, save_info
+        )
+    return create_feedback_message(
+        config.prompt_args,
+        public_result,
+        diagnostic=diagnostic,
+        visualizations=visualizations,
+        visualized_case_indices=rendered_indices,
+    )
 
 
 def _delete_previous_self_refine_conversation(save_info: SaveInfo, i: int) -> None:
@@ -409,7 +484,7 @@ def run_self_refinement(
         try:
             response = safe_generation(
                 model_config=model_config,
-                user_prompt=create_feedback_message(config.prompt_args, public_result)[0],
+                user_prompt=_build_refinement_user_prompt(config, session, public_result, save_info),
                 message_history=message_history,  # including system prompt
                 timeout=TIMEOUT_SECONDS,
                 num_retries=MAX_RETRIES,

--- a/src/ale_bench_eval/selection.py
+++ b/src/ale_bench_eval/selection.py
@@ -1,8 +1,10 @@
+from collections.abc import Sequence
 from typing import Any, Literal, TypeGuard
 
 import numpy as np
 
 from ale_bench.data import ScoreType
+from ale_bench.result import CaseResult, JudgeResult
 from ale_bench_eval.language_config import ALL_CODE_LANGUAGES_SET, StoredCodeLanguage
 
 VALID_CODE_LANGUAGES = {"", "any", *ALL_CODE_LANGUAGES_SET}
@@ -29,6 +31,32 @@ def get_solution_info(target_result: dict[str, Any]) -> tuple[StoredCodeLanguage
 
 def get_worst_score(score_type: ScoreType) -> int:
     return -1 if score_type == ScoreType.MAXIMIZE else 1000000000000000000
+
+
+def select_worst_case_indices(
+    case_results: Sequence[CaseResult],
+    score_type: ScoreType,
+    k: int,
+) -> list[int]:
+    """Select the indices of the k worst cases; non-AC cases rank worse than any accepted case.
+
+    Args:
+        case_results: Per-case results to rank.
+        score_type: Score type (MINIMIZE or MAXIMIZE).
+        k: Number of indices to return.
+
+    Returns:
+        list of case indices ordered from worst to less bad.
+
+    """
+    sign = -1 if score_type == ScoreType.MAXIMIZE else 1
+
+    def badness(idx: int) -> tuple[int, int, int]:
+        case_result = case_results[idx]
+        is_accepted = case_result.judge_result == JudgeResult.ACCEPTED
+        return (int(is_accepted), -sign * case_result.absolute_score, idx)
+
+    return sorted(range(len(case_results)), key=badness)[:k]
 
 
 def select_solution_from_repeated_sampling(

--- a/tests/test_eval_strategies.py
+++ b/tests/test_eval_strategies.py
@@ -1,0 +1,186 @@
+from typing import Literal
+from unittest.mock import MagicMock
+
+import pytest
+from PIL import Image
+from pydantic_ai import BinaryContent
+
+from ale_bench.data import ScoreType
+from ale_bench.result import CaseResult, JudgeResult, ResourceUsage, Result
+from ale_bench_eval.data_types import EvaluationConfig
+from ale_bench_eval.prompts.builder import PromptArgs, create_feedback_message, diagnostic_feedback
+from ale_bench_eval.scaffolds import _build_refinement_user_prompt
+from ale_bench_eval.selection import select_worst_case_indices
+
+
+def make_case_result(
+    absolute_score: int,
+    judge_result: JudgeResult = JudgeResult.ACCEPTED,
+    input_str: str | None = "10 20\n0 1 2",
+    output_str: str | None = "3\n",
+) -> CaseResult:
+    return CaseResult(
+        input_str=input_str,
+        output_str=output_str,
+        judge_result=judge_result,
+        message="",
+        absolute_score=absolute_score,
+        execution_time=1.0,
+        memory_usage=1024 * 1024,
+    )
+
+
+def make_result(case_results: list[CaseResult]) -> Result:
+    return Result(allow_score_non_ac=True, resource_usage=ResourceUsage(), case_results=case_results)
+
+
+def make_prompt_args(prompt_language: Literal["en", "ja"] = "en") -> PromptArgs:
+    return PromptArgs(
+        code_language="cpp20",
+        judge_version="202301",
+        prompt_language=prompt_language,
+        use_image=False,
+    )
+
+
+def make_config(
+    *,
+    feedback_diagnostic: bool = False,
+    feedback_visualization: bool = False,
+    n_feedback_worst_cases: int = 3,
+) -> EvaluationConfig:
+    return EvaluationConfig(
+        model_name="test-model",
+        n_repeated_sampling=1,
+        n_self_refine=1,
+        num_workers=1,
+        reuse_containers=False,
+        n_public_cases=None,
+        prompt_args=make_prompt_args(),
+        problem_id="ahc001",
+        lite_version=True,
+        feedback_diagnostic=feedback_diagnostic,
+        feedback_visualization=feedback_visualization,
+        n_feedback_worst_cases=n_feedback_worst_cases,
+    )
+
+
+@pytest.mark.parametrize(
+    ("scores", "score_type", "k", "expected"),
+    [
+        pytest.param([10, 30, 20], ScoreType.MAXIMIZE, 2, [0, 2], id="maximize_lowest_first"),
+        pytest.param([10, 30, 20], ScoreType.MINIMIZE, 2, [1, 2], id="minimize_highest_first"),
+        pytest.param([10, 30, 20], ScoreType.MAXIMIZE, 10, [0, 2, 1], id="k_exceeds_length"),
+        pytest.param([5, 5, 5], ScoreType.MAXIMIZE, 2, [0, 1], id="ties_prefer_lower_index"),
+    ],
+)
+def test_select_worst_case_indices(scores: list[int], score_type: ScoreType, k: int, expected: list[int]) -> None:
+    case_results = [make_case_result(score) for score in scores]
+    assert select_worst_case_indices(case_results, score_type, k) == expected
+
+
+def test_select_worst_case_indices_non_ac_ranks_worst() -> None:
+    case_results = [
+        make_case_result(1, judge_result=JudgeResult.ACCEPTED),
+        make_case_result(1000, judge_result=JudgeResult.TIME_LIMIT_EXCEEDED),
+        make_case_result(2, judge_result=JudgeResult.ACCEPTED),
+    ]
+    assert select_worst_case_indices(case_results, ScoreType.MAXIMIZE, 2) == [1, 0]
+
+
+@pytest.mark.parametrize("prompt_language", ["en", "ja"])
+def test_diagnostic_feedback_contents(prompt_language: Literal["en", "ja"]) -> None:
+    result = make_result(
+        [
+            make_case_result(100, input_str="7 3\nrest"),
+            make_case_result(5, input_str=None),
+            make_case_result(50, judge_result=JudgeResult.WRONG_ANSWER),
+        ]
+    )
+    feedback = diagnostic_feedback(make_prompt_args(prompt_language), result, worst_indices=[1, 2])
+    assert 'Case 1: params="7 3", score=100' in feedback
+    assert 'Case 2: params="N/A", score=5 (WORST)' in feedback
+    assert 'Case 3: params="10 20", score=50, judge=WRONG_ANSWER (WORST)' in feedback
+    assert "score=100 (WORST)" not in feedback  # Case 1 is not marked as worst
+
+
+def test_create_feedback_message_backward_compatible() -> None:
+    args = make_prompt_args()
+    result = make_result([make_case_result(100)])
+    message = create_feedback_message(args, result)
+    assert len(message) == 1
+    assert isinstance(message[0], str)
+    assert "Overall absolute score: 100" in message[0]
+    # No result available (e.g. no code block found in the response)
+    no_result_message = create_feedback_message(args, None)
+    assert len(no_result_message) == 1
+    assert isinstance(no_result_message[0], str)
+    assert "No public result is available" in no_result_message[0]
+
+
+def test_create_feedback_message_with_diagnostic_and_visualizations() -> None:
+    args = make_prompt_args()
+    result = make_result([make_case_result(100)])
+    image = BinaryContent(data=b"fake-png", media_type="image/png")
+    message = create_feedback_message(
+        args,
+        result,
+        diagnostic="\n[Per-case diagnostics]\ncase table",
+        visualizations=[image],
+        visualized_case_indices=[0],
+    )
+    assert len(message) == 3
+    assert isinstance(message[0], str)
+    assert "[Per-case diagnostics]" in message[0]
+    assert "worst-scoring cases: 1" in message[0]
+    assert message[1] is image
+    assert isinstance(message[2], str)
+
+
+def make_mock_session(problem_id: str, score_type: ScoreType = ScoreType.MAXIMIZE) -> MagicMock:
+    session = MagicMock()
+    session.problem.metadata.problem_id = problem_id
+    session.problem.metadata.score_type = score_type
+    return session
+
+
+def test_build_refinement_user_prompt_defaults_to_plain_feedback() -> None:
+    config = make_config()
+    session = make_mock_session("ahc001")
+    result = make_result([make_case_result(100)])
+    message = _build_refinement_user_prompt(config, session, result, MagicMock())
+    assert message == create_feedback_message(config.prompt_args, result)
+    session.local_visualization.assert_not_called()
+
+
+def test_build_refinement_user_prompt_skips_visualization_for_no_local_vis() -> None:
+    config = make_config(feedback_visualization=True)
+    session = make_mock_session("ahc016")
+    result = make_result([make_case_result(100)])
+    message = _build_refinement_user_prompt(config, session, result, MagicMock())
+    session.local_visualization.assert_not_called()
+    assert all(not isinstance(content, BinaryContent) for content in message)
+
+
+def test_build_refinement_user_prompt_renders_and_drops_none_images() -> None:
+    config = make_config(feedback_visualization=True, n_feedback_worst_cases=2)
+    session = make_mock_session("ahc001")
+    session.local_visualization.return_value = [None, Image.new("RGB", (4, 4))]
+    result = make_result([make_case_result(10), make_case_result(20), make_case_result(30)])
+    message = _build_refinement_user_prompt(config, session, result, MagicMock())
+    (called_inputs, called_outputs), _ = session.local_visualization.call_args
+    assert len(called_inputs) == len(called_outputs) == 2
+    images = [content for content in message if isinstance(content, BinaryContent)]
+    assert len(images) == 1
+    # The surviving image belongs to case index 1 (the second-worst case)
+    assert isinstance(message[0], str)
+    assert "worst-scoring cases: 2" in message[0]
+
+
+def test_build_refinement_user_prompt_visualization_failure_degrades() -> None:
+    config = make_config(feedback_visualization=True)
+    session = make_mock_session("ahc001")
+    session.local_visualization.side_effect = RuntimeError("docker down")
+    result = make_result([make_case_result(100)])
+    message = _build_refinement_user_prompt(config, session, result, MagicMock())
+    assert all(not isinstance(content, BinaryContent) for content in message)


### PR DESCRIPTION
## Summary

Two opt-in feedback enrichments for the self-refinement loop in `ale_bench_eval`, motivated by how human AHC participants work: they analyze which input regimes fail and inspect the visualizer, rather than looking only at an overall score.

- `--feedback_diagnostic`: the feedback message lists every public case with its instance parameters (the first line of its input) and score, marks the worst cases, and asks the model to state a hypothesis about which input regimes its solution handles poorly before refining.
- `--feedback_visualization`: the final states of the worst-scoring cases are rendered via `session.local_visualization` and attached as images to the feedback message for multimodal models.

## Design notes

- Both flags default to off. With flags off, the feedback message is byte-identical to the current one, so existing runs and comparisons are unaffected.
- Resume needs no new persisted state: `input_str`/`output_str` already survive the `Result` JSON round-trip, and images are re-rendered each round.
- Visualization degrades gracefully: rendering failures fall back to text-only feedback, and problems without a local visualizer (`NO_LOCAL_VIS`) are skipped.
- New settings are written to `experiment_settings.json` and checked on resume with backward-compatible defaults, so existing experiment directories still resume.

## Testing

- New `tests/test_eval_strategies.py` (no Docker or API keys): worst-case selection for both score types, diagnostic feedback formatting (en/ja), backward compatibility of `create_feedback_message`, the `NO_LOCAL_VIS` guard, and graceful degradation on rendering failure.
- `ruff check`, `ruff format --check`, `ty check`, and `pytest -m "not docker"` (709 passed) are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)