### PR TITLE
Add evolutionary search and budget-aware strategies

### DIFF
--- a/src/ale_bench_eval/__main__.py
+++ b/src/ale_bench_eval/__main__.py
@@ -74,6 +74,9 @@ def evaluate_contest(
     root_path: Path | None = None,
     llm_semaphore: BoundedSemaphore | None = None,
     max_repeated_sampling_workers: int | None = None,
+    feedback_diagnostic: bool = False,
+    feedback_visualization: bool = False,
+    n_feedback_worst_cases: int = 3,
 ) -> None:
     """Main evaluation function orchestrating the entire benchmarking process."""
     start_time = get_now_utc()
@@ -90,6 +93,9 @@ def evaluate_contest(
         problem_id=problem_id,
         lite_version=lite_version,
         root_path=root_path,
+        feedback_diagnostic=feedback_diagnostic,
+        feedback_visualization=feedback_visualization,
+        n_feedback_worst_cases=n_feedback_worst_cases,
     )
 
     # Initialize session and logging
@@ -257,6 +263,9 @@ def _run_evaluation_task(
     root_path: Path,
     llm_semaphore: BoundedSemaphore | None,
     max_repeated_sampling_workers: int | None,
+    feedback_diagnostic: bool,
+    feedback_visualization: bool,
+    n_feedback_worst_cases: int,
 ) -> tuple[str, bool, str]:
     """Wrapper function for parallel evaluation execution."""
     try:
@@ -276,6 +285,9 @@ def _run_evaluation_task(
             root_path=root_path,
             llm_semaphore=llm_semaphore,
             max_repeated_sampling_workers=max_repeated_sampling_workers,
+            feedback_diagnostic=feedback_diagnostic,
+            feedback_visualization=feedback_visualization,
+            n_feedback_worst_cases=n_feedback_worst_cases,
         )
         print(f"✅ Completed: {model_name} on {problem_id}")
     except Exception as e:
@@ -304,6 +316,9 @@ def main(
     use_statement_image: bool = False,
     root_path: str | None = None,
     skip_llm_inference: bool = False,
+    feedback_diagnostic: bool = False,
+    feedback_visualization: bool = False,
+    n_feedback_worst_cases: int = 3,
 ) -> None:
     """Main entry point for running LLM benchmarking evaluation."""
     start_time = get_now_utc()
@@ -410,6 +425,15 @@ def main(
         if existing_settings["selection_method"] != selection_method:
             msg = "Experiment settings already exist with different selection_method"
             raise ValueError(msg)
+        if existing_settings.get("feedback_diagnostic", False) != feedback_diagnostic:
+            msg = "Experiment settings already exist with different feedback_diagnostic"
+            raise ValueError(msg)
+        if existing_settings.get("feedback_visualization", False) != feedback_visualization:
+            msg = "Experiment settings already exist with different feedback_visualization"
+            raise ValueError(msg)
+        if existing_settings.get("n_feedback_worst_cases", 3) != n_feedback_worst_cases:
+            msg = "Experiment settings already exist with different n_feedback_worst_cases"
+            raise ValueError(msg)
     # Save (update) experiment settings
     with setting_path.open("w") as f:
         json.dump(
@@ -429,6 +453,9 @@ def main(
                 "max_repeated_sampling_workers": max_repeated_sampling_workers,
                 "problem_ids_type": problem_ids_type,
                 "selection_method": selection_method,
+                "feedback_diagnostic": feedback_diagnostic,
+                "feedback_visualization": feedback_visualization,
+                "n_feedback_worst_cases": n_feedback_worst_cases,
             },
             f,
             indent=4,
@@ -475,6 +502,9 @@ def main(
                     exp_root,
                     llm_semaphore,
                     max_repeated_sampling_workers,
+                    feedback_diagnostic,
+                    feedback_visualization,
+                    n_feedback_worst_cases,
                 ): problem_id
                 for problem_id in problem_ids
             }

--- a/src/ale_bench_eval/__main__.py
+++ b/src/ale_bench_eval/__main__.py
@@ -26,7 +26,12 @@ from ale_bench_eval.prompts.builder import (
 )
 from ale_bench_eval.safe_ale_session import start_ale_bench_session
 from ale_bench_eval.safe_generation import parse_model_config
-from ale_bench_eval.scaffolds import run_repeated_sampling, run_self_refinement
+from ale_bench_eval.scaffolds import (
+    run_budget_aware,
+    run_evolutionary_search,
+    run_repeated_sampling,
+    run_self_refinement,
+)
 from ale_bench_eval.selection import (
     select_solution_from_repeated_sampling,
     select_solution_from_self_refine,
@@ -77,6 +82,10 @@ def evaluate_contest(
     feedback_diagnostic: bool = False,
     feedback_visualization: bool = False,
     n_feedback_worst_cases: int = 3,
+    strategy: Literal["self_refine", "evolution", "budget"] = "self_refine",
+    evolution_population_size: int = 4,
+    evolution_crossover_prob: float = 0.3,
+    evolution_seed: int = 0,
 ) -> None:
     """Main evaluation function orchestrating the entire benchmarking process."""
     start_time = get_now_utc()
@@ -96,6 +105,10 @@ def evaluate_contest(
         feedback_diagnostic=feedback_diagnostic,
         feedback_visualization=feedback_visualization,
         n_feedback_worst_cases=n_feedback_worst_cases,
+        strategy=strategy,
+        evolution_population_size=evolution_population_size,
+        evolution_crossover_prob=evolution_crossover_prob,
+        evolution_seed=evolution_seed,
     )
 
     # Initialize session and logging
@@ -144,7 +157,7 @@ def evaluate_contest(
         selection_method,
     )
 
-    # Phase 3: Self-refinement
+    # Phase 3: Iterative improvement (self-refinement, evolutionary search, or budget-aware)
     if results_repeated_sampling[selected_index_repeated_sampling]["is_context_length_overflow"]:
         msg = "Context length overflow occurred in the selected repeated sampling result."
         raise ValueError(msg)
@@ -156,16 +169,39 @@ def evaluate_contest(
         initial_public_result = save_info.load_ale_bench_results(
             f"repeated_sampling_results_{selected_index_repeated_sampling}.json"
         )
-    results_self_refine = run_self_refinement(
-        config=config,
-        model_config=model_config,
-        session=session,
-        initial_message_history=initial_conversations.all_messages(),
-        initial_public_result=initial_public_result,
-        initial_result=results_repeated_sampling[selected_index_repeated_sampling],
-        save_info=save_info,
-        llm_semaphore=llm_semaphore,
-    )
+    if strategy == "evolution":
+        results_phase3 = run_evolutionary_search(
+            config=config,
+            model_config=model_config,
+            session=session,
+            results_repeated_sampling=results_repeated_sampling,
+            initial_result=results_repeated_sampling[selected_index_repeated_sampling],
+            save_info=save_info,
+            llm_semaphore=llm_semaphore,
+        )
+    elif strategy == "budget":
+        results_phase3 = run_budget_aware(
+            config=config,
+            model_config=model_config,
+            session=session,
+            initial_message_history=initial_conversations.all_messages(),
+            initial_public_result=initial_public_result,
+            initial_result=results_repeated_sampling[selected_index_repeated_sampling],
+            save_info=save_info,
+            llm_semaphore=llm_semaphore,
+        )
+    else:
+        results_phase3 = run_self_refinement(
+            config=config,
+            model_config=model_config,
+            session=session,
+            initial_message_history=initial_conversations.all_messages(),
+            initial_public_result=initial_public_result,
+            initial_result=results_repeated_sampling[selected_index_repeated_sampling],
+            save_info=save_info,
+            llm_semaphore=llm_semaphore,
+        )
+    phase3_name = strategy
 
     # Phase 4: Private evaluation
     solutions_to_evaluate = [
@@ -175,23 +211,23 @@ def evaluate_contest(
             code_language=selected_code_language_repeated_sampling,
         ),
     ]
-    self_refine_target_indices = power_of_two_indices(n_self_refine)
-    for i in self_refine_target_indices:
+    phase3_target_indices = power_of_two_indices(n_self_refine)
+    for i in phase3_target_indices:
         (
-            selected_code_language_self_refine_at_i,
-            selected_code_self_refine_at_i,
-            selected_index_self_refine_at_i,
+            selected_code_language_phase3_at_i,
+            selected_code_phase3_at_i,
+            selected_index_phase3_at_i,
         ) = select_solution_from_self_refine(
-            results_self_refine=results_self_refine,
+            results_self_refine=results_phase3,
             score_type=score_type,
             n_max_refine=i,
         )
-        save_info.logger.info("Selected solution index: %s for self-refine at %s", selected_index_self_refine_at_i, i)
+        save_info.logger.info("Selected solution index: %s for %s at %s", selected_index_phase3_at_i, phase3_name, i)
         solutions_to_evaluate.append(
             Solution(
-                name=f"self_refine_{i}",
-                code=selected_code_self_refine_at_i,
-                code_language=selected_code_language_self_refine_at_i,
+                name=f"{phase3_name}_{i}",
+                code=selected_code_phase3_at_i,
+                code_language=selected_code_language_phase3_at_i,
             ),
         )
     private_result = run_private_evaluation(config, session, solutions_to_evaluate, save_info)
@@ -219,17 +255,17 @@ def evaluate_contest(
             "total_cost": repeated_sampling_total_cost,
         },
     }
-    for i in self_refine_target_indices:
-        self_refine_total_tokens, self_refine_total_cost = estimate_total_cost(
-            save_info.results / "self_refine_results.json",
+    for i in phase3_target_indices:
+        phase3_total_tokens, phase3_total_cost = estimate_total_cost(
+            save_info.results / f"{phase3_name}_results.json",
             n_max_refine=i,
         )
         save_info.logger.info(
-            "Self-refine %s total cost: %s, total tokens: %s", i, self_refine_total_cost, self_refine_total_tokens
+            "%s %s total cost: %s, total tokens: %s", phase3_name, i, phase3_total_cost, phase3_total_tokens
         )
-        total_cost[f"self_refine_{i}"] = {
-            "total_tokens": self_refine_total_tokens,
-            "total_cost": self_refine_total_cost,
+        total_cost[f"{phase3_name}_{i}"] = {
+            "total_tokens": phase3_total_tokens,
+            "total_cost": phase3_total_cost,
         }
     save_info.save_results("total_cost.json", total_cost)
     save_info.logger.info("Total cost saved.")
@@ -266,6 +302,10 @@ def _run_evaluation_task(
     feedback_diagnostic: bool,
     feedback_visualization: bool,
     n_feedback_worst_cases: int,
+    strategy: Literal["self_refine", "evolution", "budget"],
+    evolution_population_size: int,
+    evolution_crossover_prob: float,
+    evolution_seed: int,
 ) -> tuple[str, bool, str]:
     """Wrapper function for parallel evaluation execution."""
     try:
@@ -288,6 +328,10 @@ def _run_evaluation_task(
             feedback_diagnostic=feedback_diagnostic,
             feedback_visualization=feedback_visualization,
             n_feedback_worst_cases=n_feedback_worst_cases,
+            strategy=strategy,
+            evolution_population_size=evolution_population_size,
+            evolution_crossover_prob=evolution_crossover_prob,
+            evolution_seed=evolution_seed,
         )
         print(f"✅ Completed: {model_name} on {problem_id}")
     except Exception as e:
@@ -319,6 +363,10 @@ def main(
     feedback_diagnostic: bool = False,
     feedback_visualization: bool = False,
     n_feedback_worst_cases: int = 3,
+    strategy: Literal["self_refine", "evolution", "budget"] = "self_refine",
+    evolution_population_size: int = 4,
+    evolution_crossover_prob: float = 0.3,
+    evolution_seed: int = 0,
 ) -> None:
     """Main entry point for running LLM benchmarking evaluation."""
     start_time = get_now_utc()
@@ -329,6 +377,10 @@ def main(
     code_language = cast("EvalCodeLanguage", str(code_language).strip())
     judge_version = cast("EvalJudgeVersion", str(judge_version).strip())
     prompt_language = cast('Literal["en", "ja"]', str(prompt_language).strip())
+    strategy = cast('Literal["self_refine", "evolution", "budget"]', str(strategy).strip())
+    if strategy not in {"self_refine", "evolution", "budget"}:
+        msg = f"Unknown strategy: {strategy}"
+        raise ValueError(msg)
 
     if n_repeated_sampling < 1:
         msg = "n_repeated_sampling must be at least 1"
@@ -434,6 +486,18 @@ def main(
         if existing_settings.get("n_feedback_worst_cases", 3) != n_feedback_worst_cases:
             msg = "Experiment settings already exist with different n_feedback_worst_cases"
             raise ValueError(msg)
+        if existing_settings.get("strategy", "self_refine") != strategy:
+            msg = "Experiment settings already exist with different strategy"
+            raise ValueError(msg)
+        if existing_settings.get("evolution_population_size", 4) != evolution_population_size:
+            msg = "Experiment settings already exist with different evolution_population_size"
+            raise ValueError(msg)
+        if existing_settings.get("evolution_crossover_prob", 0.3) != evolution_crossover_prob:
+            msg = "Experiment settings already exist with different evolution_crossover_prob"
+            raise ValueError(msg)
+        if existing_settings.get("evolution_seed", 0) != evolution_seed:
+            msg = "Experiment settings already exist with different evolution_seed"
+            raise ValueError(msg)
     # Save (update) experiment settings
     with setting_path.open("w") as f:
         json.dump(
@@ -456,6 +520,10 @@ def main(
                 "feedback_diagnostic": feedback_diagnostic,
                 "feedback_visualization": feedback_visualization,
                 "n_feedback_worst_cases": n_feedback_worst_cases,
+                "strategy": strategy,
+                "evolution_population_size": evolution_population_size,
+                "evolution_crossover_prob": evolution_crossover_prob,
+                "evolution_seed": evolution_seed,
             },
             f,
             indent=4,
@@ -505,6 +573,10 @@ def main(
                     feedback_diagnostic,
                     feedback_visualization,
                     n_feedback_worst_cases,
+                    strategy,
+                    evolution_population_size,
+                    evolution_crossover_prob,
+                    evolution_seed,
                 ): problem_id
                 for problem_id in problem_ids
             }

--- a/src/ale_bench_eval/data_types.py
+++ b/src/ale_bench_eval/data_types.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -30,3 +31,7 @@ class EvaluationConfig:
     feedback_diagnostic: bool = False
     feedback_visualization: bool = False
     n_feedback_worst_cases: int = 3
+    strategy: Literal["self_refine", "evolution", "budget"] = "self_refine"
+    evolution_population_size: int = 4
+    evolution_crossover_prob: float = 0.3
+    evolution_seed: int = 0

--- a/src/ale_bench_eval/data_types.py
+++ b/src/ale_bench_eval/data_types.py
@@ -27,3 +27,6 @@ class EvaluationConfig:
     problem_id: str
     lite_version: bool
     root_path: Path | None = None
+    feedback_diagnostic: bool = False
+    feedback_visualization: bool = False
+    n_feedback_worst_cases: int = 3

--- a/src/ale_bench_eval/prompts/builder.py
+++ b/src/ale_bench_eval/prompts/builder.py
@@ -10,10 +10,14 @@ from ale_bench.result import CaseResult, JudgeResult, Result
 from ale_bench.utils import parse_statement
 from ale_bench_eval.language_config import EvalCodeLanguage, EvalJudgeVersion, get_any_languages
 from ale_bench_eval.prompts.texts import (
+    BUDGET_ACTION_MATCH,
+    BUDGET_ACTION_PROMPT,
     CODE_BLOCK_MATCH,
     CODE_BLOCK_STRING,
     CONSIDERATION_PROMPT,
     DIAGNOSTIC_FEEDBACK_PROMPT,
+    EVOLUTION_CROSSOVER_PROMPT,
+    EVOLUTION_MUTATION_PROMPT,
     FEEDBACK_PROMPT,
     IMPLEMENTATION_ANY_PROMPT,
     IMPLEMENTATION_SPECIFIC_PROMPT,
@@ -160,6 +164,16 @@ def result_feedback(args: PromptArgs, result: Result | None) -> str:
     return feedback
 
 
+def refine_instruction(args: PromptArgs) -> str:
+    if args.code_language == "any":
+        return REFINE_ANY_PROMPT[args.prompt_language].substitute(
+            code_blocks=get_code_block_string_any(args.judge_version),
+        )
+    return REFINE_SPECIFIC_PROMPT[args.prompt_language].substitute(
+        code_block=CODE_BLOCK_STRING[args.code_language],
+    )
+
+
 def diagnostic_feedback(args: PromptArgs, result: Result, worst_indices: list[int]) -> str:
     worst_set = set(worst_indices)
     case_lines = []
@@ -185,20 +199,69 @@ def create_feedback_message(
     feedback = result_feedback(args, public_result)
     if diagnostic is not None:
         feedback += diagnostic
-    if args.code_language == "any":
-        refine_prompt = REFINE_ANY_PROMPT[args.prompt_language].substitute(
-            code_blocks=get_code_block_string_any(args.judge_version),
-        )
-    else:
-        refine_prompt = REFINE_SPECIFIC_PROMPT[args.prompt_language].substitute(
-            code_block=CODE_BLOCK_STRING[args.code_language],
-        )
+    refine_prompt = refine_instruction(args)
     feedback_prompt = FEEDBACK_PROMPT[args.prompt_language].substitute(feedback=feedback)
     if not visualizations:
         return [feedback_prompt + refine_prompt]
     case_indices = ", ".join(str(idx + 1) for idx in visualized_case_indices or [])
     feedback_prompt += VIS_FEEDBACK_PROMPT[args.prompt_language].substitute(case_indices=case_indices)
     return [feedback_prompt, *visualizations, refine_prompt]
+
+
+def create_mutation_message(
+    args: PromptArgs,
+    problem: Problem,
+    parent_code: str,
+    parent_feedback: str,
+    image_format: Literal["jpeg", "png", "webp"] = "png",
+) -> list[str | BinaryContent]:
+    contents = create_initial_message(args, problem, image_format)
+    operator_prompt = EVOLUTION_MUTATION_PROMPT[args.prompt_language].substitute(
+        parent_code=parent_code,
+        parent_feedback=parent_feedback,
+    )
+    merged = merge_text_contents([*contents, operator_prompt + refine_instruction(args)])
+    return convert_pillow_to_binary(merged, image_format)
+
+
+def create_crossover_message(
+    args: PromptArgs,
+    problem: Problem,
+    code_a: str,
+    score_a: int,
+    code_b: str,
+    score_b: int,
+    image_format: Literal["jpeg", "png", "webp"] = "png",
+) -> list[str | BinaryContent]:
+    contents = create_initial_message(args, problem, image_format)
+    operator_prompt = EVOLUTION_CROSSOVER_PROMPT[args.prompt_language].substitute(
+        code_a=code_a,
+        score_a=score_a,
+        code_b=code_b,
+        score_b=score_b,
+    )
+    merged = merge_text_contents([*contents, operator_prompt + refine_instruction(args)])
+    return convert_pillow_to_binary(merged, image_format)
+
+
+def create_budget_action_message(
+    args: PromptArgs,
+    remaining_budget: int,
+    history_rows: list[tuple[int, str, int]],
+) -> str:
+    history_table = "\n".join(f"- Attempt {index} ({action}): score={score}" for index, action, score in history_rows)
+    return BUDGET_ACTION_PROMPT[args.prompt_language].substitute(
+        remaining_budget=remaining_budget,
+        history_table=history_table,
+    )
+
+
+def parse_budget_action(response: str) -> Literal["sample", "refine"]:
+    """Parse the controller's action choice; the last match wins, and anything else means refine."""
+    matches = BUDGET_ACTION_MATCH.findall(response)
+    if not matches:
+        return "refine"
+    return "sample" if matches[-1].upper() == "SAMPLE" else "refine"
 
 
 def get_code_from_response(response: str, code_language: str, judge_version: str) -> tuple[str, str]:

--- a/src/ale_bench_eval/prompts/builder.py
+++ b/src/ale_bench_eval/prompts/builder.py
@@ -13,6 +13,7 @@ from ale_bench_eval.prompts.texts import (
     CODE_BLOCK_MATCH,
     CODE_BLOCK_STRING,
     CONSIDERATION_PROMPT,
+    DIAGNOSTIC_FEEDBACK_PROMPT,
     FEEDBACK_PROMPT,
     IMPLEMENTATION_ANY_PROMPT,
     IMPLEMENTATION_SPECIFIC_PROMPT,
@@ -22,6 +23,7 @@ from ale_bench_eval.prompts.texts import (
     REFINE_ANY_PROMPT,
     REFINE_SPECIFIC_PROMPT,
     SYSTEM_PROMPT,
+    VIS_FEEDBACK_PROMPT,
     get_code_block_string_any,
     get_code_language_libraries,
     get_code_language_libraries_any,
@@ -158,21 +160,45 @@ def result_feedback(args: PromptArgs, result: Result | None) -> str:
     return feedback
 
 
-def create_feedback_message(args: PromptArgs, public_result: Result | None) -> list[str]:
+def diagnostic_feedback(args: PromptArgs, result: Result, worst_indices: list[int]) -> str:
+    worst_set = set(worst_indices)
+    case_lines = []
+    for idx, case_result in enumerate(result.case_results):
+        params = case_result.input_str.split("\n", 1)[0].strip() if case_result.input_str else "N/A"
+        line = f'- Case {idx + 1}: params="{params}", score={case_result.absolute_score}'
+        if case_result.judge_result != JudgeResult.ACCEPTED:
+            line += f", judge={case_result.judge_result.value}"
+        if idx in worst_set:
+            line += " (WORST)"
+        case_lines.append(line)
+    return DIAGNOSTIC_FEEDBACK_PROMPT[args.prompt_language].substitute(case_table="\n".join(case_lines))
+
+
+def create_feedback_message(
+    args: PromptArgs,
+    public_result: Result | None,
+    *,
+    diagnostic: str | None = None,
+    visualizations: list[BinaryContent] | None = None,
+    visualized_case_indices: list[int] | None = None,
+) -> list[str | BinaryContent]:
     feedback = result_feedback(args, public_result)
+    if diagnostic is not None:
+        feedback += diagnostic
     if args.code_language == "any":
-        return [
-            FEEDBACK_PROMPT[args.prompt_language].substitute(feedback=feedback)
-            + REFINE_ANY_PROMPT[args.prompt_language].substitute(
-                code_blocks=get_code_block_string_any(args.judge_version),
-            )
-        ]
-    return [
-        FEEDBACK_PROMPT[args.prompt_language].substitute(feedback=feedback)
-        + REFINE_SPECIFIC_PROMPT[args.prompt_language].substitute(
+        refine_prompt = REFINE_ANY_PROMPT[args.prompt_language].substitute(
+            code_blocks=get_code_block_string_any(args.judge_version),
+        )
+    else:
+        refine_prompt = REFINE_SPECIFIC_PROMPT[args.prompt_language].substitute(
             code_block=CODE_BLOCK_STRING[args.code_language],
         )
-    ]
+    feedback_prompt = FEEDBACK_PROMPT[args.prompt_language].substitute(feedback=feedback)
+    if not visualizations:
+        return [feedback_prompt + refine_prompt]
+    case_indices = ", ".join(str(idx + 1) for idx in visualized_case_indices or [])
+    feedback_prompt += VIS_FEEDBACK_PROMPT[args.prompt_language].substitute(case_indices=case_indices)
+    return [feedback_prompt, *visualizations, refine_prompt]
 
 
 def get_code_from_response(response: str, code_language: str, judge_version: str) -> tuple[str, str]:

--- a/src/ale_bench_eval/prompts/texts.py
+++ b/src/ale_bench_eval/prompts/texts.py
@@ -681,6 +681,36 @@ FEEDBACK_PROMPT_WITH_SUMMARY = {
         "単純なバグ修正、新しいアルゴリズムの導入、または小さな変更から大きな変更まで、どの程度の変更でも構いません。"
     ),
 }
+DIAGNOSTIC_FEEDBACK_PROMPT = {
+    "en": Template(
+        "\n\n[Per-case diagnostics]\n"
+        "Each public case is listed with its instance parameters (the first line of its input) and its score. "
+        "The worst-scoring cases are marked with (WORST).\n"
+        "${case_table}\n"
+        "Before refining your code, state a hypothesis about which input regimes "
+        "(e.g. parameter ranges) your solution handles poorly and why. "
+    ),
+    "ja": Template(
+        "\n\n[ケースごとの診断]\n"
+        "各パブリックケースについて、インスタンスパラメータ(入力の1行目)とスコアを列挙します。"
+        "スコアが最も悪いケースには (WORST) が付いています。\n"
+        "${case_table}\n"
+        "コードを改良する前に、あなたの解法がどのような入力領域(パラメータ範囲など)で"
+        "性能が悪いのか、そしてその理由について仮説を述べてください。"
+    ),
+}
+VIS_FEEDBACK_PROMPT = {
+    "en": Template(
+        "\n\nThe images below visualize the final state of your solution "
+        "on the worst-scoring cases: ${case_indices}. "
+        "Inspect them for structural weaknesses before refining your code.\n"
+    ),
+    "ja": Template(
+        "\n\n以下の画像は、スコアが最も悪いケース(${case_indices})における"
+        "あなたの解法の最終状態を可視化したものです。"
+        "コードを改良する前に、構造的な弱点がないか確認してください。\n"
+    ),
+}
 REFINE_ANY_PROMPT = {
     "en": Template(
         "Your solution code should be written in the specified code block as follows:\n${code_blocks}"

--- a/src/ale_bench_eval/prompts/texts.py
+++ b/src/ale_bench_eval/prompts/texts.py
@@ -725,6 +725,58 @@ REFINE_SPECIFIC_PROMPT = {
     ),
     "ja": Template("解法コードは、${code_block}コードブロックに記述してください。"),
 }
+EVOLUTION_MUTATION_PROMPT = {
+    "en": Template(
+        "\n\nBelow is one of your candidate solutions for this problem and its public test feedback.\n"
+        "[Candidate solution]\n```\n${parent_code}\n```\n\n"
+        "[Feedback]\n${parent_feedback}\n\n"
+        "Analyze the weaknesses of this candidate and produce an improved solution. "
+        "It can be a simple bug fix, the introduction of a new algorithm, or any degree of change from minor to major. "
+    ),
+    "ja": Template(
+        "\n\nこの問題に対するあなたの候補解のひとつと、そのパブリックテストのフィードバックを以下に示します。\n"
+        "[候補解]\n```\n${parent_code}\n```\n\n"
+        "[フィードバック]\n${parent_feedback}\n\n"
+        "この候補解の弱点を分析し、改良した解法を作成してください。"
+        "単純なバグ修正、新しいアルゴリズムの導入、または小さな変更から大きな変更まで、どの程度の変更でも構いません。"
+    ),
+}
+EVOLUTION_CROSSOVER_PROMPT = {
+    "en": Template(
+        "\n\nBelow are two of your candidate solutions for this problem with different scores.\n"
+        "[Candidate solution A] (score: ${score_a})\n```\n${code_a}\n```\n\n"
+        "[Candidate solution B] (score: ${score_b})\n```\n${code_b}\n```\n\n"
+        "Identify the distinct strengths of each candidate and combine them into a single better solution. "
+    ),
+    "ja": Template(
+        "\n\nこの問題に対する、スコアの異なるあなたの2つの候補解を以下に示します。\n"
+        "[候補解A] (スコア: ${score_a})\n```\n${code_a}\n```\n\n"
+        "[候補解B] (スコア: ${score_b})\n```\n${code_b}\n```\n\n"
+        "それぞれの候補解の異なる強みを特定し、それらを組み合わせてより良いひとつの解法を作成してください。"
+    ),
+}
+BUDGET_ACTION_PROMPT = {
+    "en": Template(
+        "You are managing a limited budget of solution-generation calls for a heuristic programming contest.\n"
+        "You have ${remaining_budget} calls left.\n\n"
+        "[Attempt history]\n${history_table}\n\n"
+        "Choose the next action:\n"
+        "- SAMPLE: write a fresh solution from scratch with a new idea, discarding the current line of work.\n"
+        "- REFINE: continue improving your current best solution.\n"
+        "Reply with exactly one line `ACTION: SAMPLE` or `ACTION: REFINE`, followed by a one-sentence rationale."
+    ),
+    "ja": Template(
+        "あなたはヒューリスティックプログラミングコンテストにおいて、限られた解生成回数の予算を管理しています。\n"
+        "残りの生成回数は ${remaining_budget} 回です。\n\n"
+        "[試行履歴]\n${history_table}\n\n"
+        "次の行動を選択してください:\n"
+        "- SAMPLE: 現在の方針を捨て、新しいアイデアでゼロから解法を書く。\n"
+        "- REFINE: 現在のベスト解の改良を続ける。\n"
+        "`ACTION: SAMPLE` または `ACTION: REFINE` のいずれかを1行で答え、続けて理由を1文で述べてください。"
+    ),
+}
+BUDGET_ACTION_MATCH = re.compile(r"ACTION:\s*(SAMPLE|REFINE)", re.IGNORECASE)
+
 NO_SUMMARY_PROMPT = {
     "en": "Your summary was not found. The summary must be written in the Markdown format in the ```md ``` code block.",
     "ja": "あなたの要約は見つかりませんでした。要約は必ずMarkdown形式で```md ```コードブロックに記述してください。",

--- a/src/ale_bench_eval/scaffolds.py
+++ b/src/ale_bench_eval/scaffolds.py
@@ -4,9 +4,11 @@ from threading import BoundedSemaphore
 from time import sleep
 from typing import Any, TypeVar
 
+from pydantic_ai import BinaryContent
 from pydantic_ai.messages import ModelMessage, UserContent
 from pydantic_ai.run import AgentRunResult
 
+from ale_bench.constants import NO_LOCAL_VIS
 from ale_bench.result import JudgeResult, Result
 from ale_bench.session import Session
 from ale_bench_eval.calc_cost import calc_cost
@@ -15,11 +17,13 @@ from ale_bench_eval.evaluate import get_ce_code
 from ale_bench_eval.language_config import get_default_code_language
 from ale_bench_eval.logger import SaveInfo
 from ale_bench_eval.prompts.builder import (
+    convert_pillow_to_binary,
     create_feedback_message,
+    diagnostic_feedback,
     get_code_from_response,
 )
 from ale_bench_eval.safe_generation import MaxTokenError, safe_generation
-from ale_bench_eval.selection import get_worst_score
+from ale_bench_eval.selection import get_worst_score, select_worst_case_indices
 
 TIMEOUT_SECONDS = 3600
 MAX_RETRIES = 30
@@ -114,6 +118,77 @@ def _evaluate_and_save_public_result(
         lambda: save_info.save_ale_bench_results(filename, public_result),
     )
     return public_result
+
+
+def _render_worst_case_visualizations(
+    session: Session,
+    public_result: Result,
+    worst_indices: list[int],
+    save_info: SaveInfo,
+) -> tuple[list[BinaryContent], list[int]]:
+    """Render visualization images of the worst cases; failures degrade to no images."""
+    if session.problem.metadata.problem_id in NO_LOCAL_VIS:
+        return [], []
+    candidate_indices: list[int] = []
+    input_strs: list[str] = []
+    output_strs: list[str] = []
+    for idx in worst_indices:
+        case_result = public_result.case_results[idx]
+        if case_result.input_str is None or case_result.output_str is None:
+            continue
+        candidate_indices.append(idx)
+        input_strs.append(case_result.input_str)
+        output_strs.append(case_result.output_str)
+    if not candidate_indices:
+        return [], []
+    try:
+        images = session.local_visualization(input_strs, output_strs)
+    except Exception as e:
+        save_info.logger.info("Local visualization failed: %s", e)
+        return [], []
+    if not isinstance(images, list):  # scalar result for a single case
+        images = [images]
+    rendered_indices: list[int] = []
+    rendered_images = []
+    for idx, image in zip(candidate_indices, images, strict=True):
+        if image is not None:
+            rendered_indices.append(idx)
+            rendered_images.append(image)
+    binary_contents = [
+        content for content in convert_pillow_to_binary(rendered_images, "png") if isinstance(content, BinaryContent)
+    ]
+    return binary_contents, rendered_indices
+
+
+def _build_refinement_user_prompt(
+    config: EvaluationConfig,
+    session: Session,
+    public_result: Result | None,
+    save_info: SaveInfo,
+) -> list[str | BinaryContent]:
+    if public_result is None or not (config.feedback_diagnostic or config.feedback_visualization):
+        return create_feedback_message(config.prompt_args, public_result)
+    worst_indices = select_worst_case_indices(
+        public_result.case_results,
+        session.problem.metadata.score_type,
+        config.n_feedback_worst_cases,
+    )
+    diagnostic = None
+    if config.feedback_diagnostic:
+        diagnostic = diagnostic_feedback(config.prompt_args, public_result, worst_indices)
+    visualizations: list[BinaryContent] = []
+    rendered_indices: list[int] = []
+    if config.feedback_visualization:
+        visualizations, rendered_indices = _render_worst_case_visualizations(
+            session, public_result, worst_indices, save_info
+        )
+    return create_feedback_message(
+        config.prompt_args,
+        public_result,
+        diagnostic=diagnostic,
+        visualizations=visualizations,
+        visualized_case_indices=rendered_indices,
+    )
 
 
 def _delete_previous_self_refine_conversation(save_info: SaveInfo, i: int) -> None:
@@ -409,7 +484,7 @@ def run_self_refinement(
         try:
             response = safe_generation(
                 model_config=model_config,
-                user_prompt=create_feedback_message(config.prompt_args, public_result)[0],
+                user_prompt=_build_refinement_user_prompt(config, session, public_result, save_info),
                 message_history=message_history,  # including system prompt
                 timeout=TIMEOUT_SECONDS,
                 num_retries=MAX_RETRIES,

--- a/src/ale_bench_eval/scaffolds.py
+++ b/src/ale_bench_eval/scaffolds.py
@@ -1,3 +1,4 @@
+import random
 from collections.abc import Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from threading import BoundedSemaphore
@@ -9,6 +10,7 @@ from pydantic_ai.messages import ModelMessage, UserContent
 from pydantic_ai.run import AgentRunResult
 
 from ale_bench.constants import NO_LOCAL_VIS
+from ale_bench.data import ScoreType
 from ale_bench.result import JudgeResult, Result
 from ale_bench.session import Session
 from ale_bench_eval.calc_cost import calc_cost
@@ -18,17 +20,29 @@ from ale_bench_eval.language_config import get_default_code_language
 from ale_bench_eval.logger import SaveInfo
 from ale_bench_eval.prompts.builder import (
     convert_pillow_to_binary,
+    create_budget_action_message,
+    create_crossover_message,
     create_feedback_message,
+    create_initial_message,
+    create_mutation_message,
+    create_system_message,
     diagnostic_feedback,
     get_code_from_response,
+    parse_budget_action,
+    result_feedback,
 )
 from ale_bench_eval.safe_generation import MaxTokenError, safe_generation
-from ale_bench_eval.selection import get_worst_score, select_worst_case_indices
+from ale_bench_eval.selection import (
+    get_worst_score,
+    select_solution_from_self_refine,
+    select_worst_case_indices,
+)
 
 TIMEOUT_SECONDS = 3600
 MAX_RETRIES = 30
 JUDGE_MAX_RETRIES = 3
 JUDGE_RETRY_WAIT_SECONDS = 5.0
+MIN_CROSSOVER_POPULATION = 2
 
 T = TypeVar("T")
 
@@ -584,3 +598,449 @@ def run_self_refinement(
         raise RuntimeError(msg)
 
     return results_self_refine
+
+
+PopulationKey = tuple[str, int]
+
+
+def _load_phase3_results(
+    save_info: SaveInfo,
+    results_filename: str,
+    initial_result: dict[str, Any],
+) -> dict[int, dict[str, Any]]:
+    """Load (or seed) a phase-3 results dict whose keys must be continuous from 0 to n-1."""
+    if (save_info.results / results_filename).exists():
+        results_raw = save_info.load_results(results_filename)
+        results = {int(k): v for k, v in results_raw.items()}
+        save_info.logger.info("Loaded %s results from %s", len(results), results_filename)
+    else:
+        save_info.logger.info("No results found for %s, starting from scratch", results_filename)
+        results = {0: initial_result}
+    if set(results.keys()) != set(range(len(results))):
+        msg = "Results keys must be continuous from 0 to n-1"
+        raise ValueError(msg)
+    return results
+
+
+def _save_phase3_step(
+    *,
+    step_name: str,
+    i: int,
+    response: AgentRunResult[str] | None,
+    entry: dict[str, Any],
+    results: dict[int, dict[str, Any]],
+    results_filename: str,
+    conversations_filename: str,
+    save_info: SaveInfo,
+) -> None:
+    if response is not None:
+        _run_with_retries(
+            f"{step_name} conversation save",
+            save_info,
+            lambda: save_info.save_conversations(conversations_filename, response),
+        )
+    updated_results = {**results, i: entry}
+    _run_with_retries(
+        f"{step_name} summary save",
+        save_info,
+        lambda: save_info.save_results(results_filename, {str(k): v for k, v in sorted(updated_results.items())}),
+    )
+    results[i] = entry
+
+
+def _finalize_generation_step(
+    *,
+    response: AgentRunResult[str] | None,
+    code_language: str,
+    code: str,
+    is_context_length_overflow: bool,
+    config: EvaluationConfig,
+    model_config: dict[str, Any],
+    session: Session,
+    public_cases: list[str] | str | None,
+    save_info: SaveInfo,
+    filename: str,
+    extra_response: AgentRunResult[str] | None = None,
+) -> tuple[dict[str, Any], Result | None]:
+    """Evaluate a generated solution and build the standard result entry.
+
+    Token usage and cost cover both `response` and `extra_response` (e.g. a controller call).
+    """
+    overall_absolute_score = get_worst_score(session.problem.metadata.score_type)
+    public_result: Result | None = None
+    if response is not None:
+        eval_code_language = code_language
+        eval_code = code
+        is_code_empty = eval_code.strip() == ""
+        if is_code_empty:
+            if eval_code_language == "":
+                eval_code_language = get_default_code_language(config.prompt_args.judge_version)
+            eval_code = get_ce_code(eval_code_language)
+        public_result = _evaluate_and_save_public_result(
+            config=config,
+            session=session,
+            public_cases=public_cases,
+            code=eval_code,
+            code_language=eval_code_language,
+            save_info=save_info,
+            filename=filename,
+        )
+        overall_absolute_score = (
+            public_result.overall_absolute_score
+            if public_result.overall_judge_result == JudgeResult.ACCEPTED
+            else get_worst_score(session.problem.metadata.score_type)
+        )
+        save_info.logger.info("Overall absolute score: %s", overall_absolute_score)
+        if is_code_empty:
+            public_result = None
+
+    usages = [r.usage for r in (extra_response, response) if r is not None]
+    entry = {
+        "code_language": code_language,
+        "code": code,
+        "overall_absolute_score": overall_absolute_score,
+        "is_context_length_overflow": is_context_length_overflow,
+        "input_tokens": sum(int(usage.input_tokens) for usage in usages) if usages else None,
+        "output_tokens": sum(int(usage.output_tokens) for usage in usages) if usages else None,
+        "total_tokens": sum(int(usage.total_tokens) for usage in usages) if usages else None,
+        "cost": sum(calc_cost(usage, model_config["model_name"]) for usage in usages) if usages else None,
+    }
+    return entry, public_result
+
+
+def _truncate_population(
+    entries: list[tuple[PopulationKey, dict[str, Any]]],
+    size: int,
+    score_type: ScoreType,
+) -> list[tuple[PopulationKey, dict[str, Any]]]:
+    """Keep the top-`size` non-empty solutions ordered from best to worst (deterministic)."""
+    valid = [(key, entry) for key, entry in entries if str(entry.get("code", "")).strip() != ""]
+    sign = -1 if score_type == ScoreType.MAXIMIZE else 1
+    valid.sort(key=lambda item: (sign * item[1]["overall_absolute_score"], item[0]))
+    return valid[:size]
+
+
+def _pick_crossover_parents(
+    population: list[tuple[PopulationKey, dict[str, Any]]],
+) -> tuple[tuple[PopulationKey, dict[str, Any]], tuple[PopulationKey, dict[str, Any]]]:
+    """Pair the best member with the member whose score differs from it the most."""
+    best = population[0]
+    best_score = best[1]["overall_absolute_score"]
+    partner = max(population[1:], key=lambda item: abs(item[1]["overall_absolute_score"] - best_score))
+    return best, partner
+
+
+def _load_parent_feedback(
+    config: EvaluationConfig,
+    save_info: SaveInfo,
+    key: PopulationKey,
+    parent_entry: dict[str, Any],
+) -> str:
+    kind, index = key
+    try:
+        parent_result = save_info.load_ale_bench_results(f"{kind}_results_{index}.json")
+    except Exception as e:
+        save_info.logger.info("Failed to load parent result %s_%s: %s", kind, index, e)
+        return f"Overall absolute score: {parent_entry['overall_absolute_score']}"
+    return result_feedback(config.prompt_args, parent_result)
+
+
+def run_evolutionary_search(
+    config: EvaluationConfig,
+    model_config: dict[str, Any],
+    session: Session,
+    results_repeated_sampling: dict[int, dict[str, Any]],
+    initial_result: dict[str, Any],
+    save_info: SaveInfo,
+    llm_semaphore: BoundedSemaphore | None = None,
+) -> dict[int, dict[str, Any]]:
+    """Run an evolutionary search over a population of solutions.
+
+    The population is seeded with the repeated sampling results. Each iteration generates one
+    child via LLM mutation (improve one parent with its feedback) or crossover (combine two
+    score-diverse parents), evaluates it, and truncates the population by score. Operator and
+    parent choices are deterministic per (evolution_seed, iteration), which makes resuming from
+    saved results exact.
+    """
+    public_cases = None
+    if config.n_public_cases is not None:
+        public_cases = session.case_gen(list(range(config.n_public_cases)))
+
+    results_filename = "evolution_results.json"
+    results_evolution = _load_phase3_results(save_info, results_filename, initial_result)
+    initial_index = len(results_evolution)
+    if initial_index >= config.n_self_refine:
+        if not (save_info.results / results_filename).exists():  # NOTE: n_self_refine=1
+            _run_with_retries(
+                "Evolution summary save",
+                save_info,
+                lambda: save_info.save_results(results_filename, {str(k): v for k, v in results_evolution.items()}),
+            )
+        save_info.logger.info("Skipping evolution because already generated %s results", initial_index)
+        return results_evolution
+
+    score_type = session.problem.metadata.score_type
+    for i in range(initial_index, config.n_self_refine):
+        save_info.logger.info("Evolution %s/%s", i + 1, config.n_self_refine)
+        rng = random.Random(config.evolution_seed * 1_000_003 + i)  # noqa: S311 (not cryptographic)
+        # NOTE: Evolution entry 0 duplicates the selected repeated sampling entry, so exclude it
+        seed_entries = [(("repeated_sampling", j), entry) for j, entry in results_repeated_sampling.items()]
+        child_entries = [(("evolution", j), entry) for j, entry in results_evolution.items() if j > 0]
+        population = _truncate_population(seed_entries + child_entries, config.evolution_population_size, score_type)
+        if not population:
+            msg = "Evolution population is empty (no valid parent solutions)"
+            raise RuntimeError(msg)
+
+        use_crossover = len(population) >= MIN_CROSSOVER_POPULATION and rng.random() < config.evolution_crossover_prob
+        if use_crossover:
+            (key_a, parent_a), (key_b, parent_b) = _pick_crossover_parents(population)
+            user_prompt = create_crossover_message(
+                config.prompt_args,
+                session.problem,
+                parent_a["code"],
+                parent_a["overall_absolute_score"],
+                parent_b["code"],
+                parent_b["overall_absolute_score"],
+            )
+            operation = "crossover"
+            parents = [f"{key_a[0]}_{key_a[1]}", f"{key_b[0]}_{key_b[1]}"]
+        else:
+            parent_key, parent_entry = population[rng.randrange(len(population))]
+            parent_feedback = _load_parent_feedback(config, save_info, parent_key, parent_entry)
+            user_prompt = create_mutation_message(
+                config.prompt_args,
+                session.problem,
+                parent_entry["code"],
+                parent_feedback,
+            )
+            operation = "mutation"
+            parents = [f"{parent_key[0]}_{parent_key[1]}"]
+        save_info.logger.info("Evolution operation: %s on %s", operation, parents)
+
+        is_context_length_overflow = False
+        response: AgentRunResult[str] | None = None
+        code_language = ""
+        code = ""
+        try:
+            response = safe_generation(
+                model_config=model_config,
+                user_prompt=user_prompt,
+                system_prompt=create_system_message(config.prompt_args),
+                timeout=TIMEOUT_SECONDS,
+                num_retries=MAX_RETRIES,
+                llm_semaphore=llm_semaphore,
+            )
+            code_language, code = get_code_from_response(
+                response.output,
+                config.prompt_args.code_language,
+                config.prompt_args.judge_version,
+            )
+        except MaxTokenError as e:
+            # NOTE: Prompts are stateless and bounded, so this should be rare; skip this child
+            save_info.logger.info("Context length overflow for evolution %s: %s", i, e)
+            is_context_length_overflow = True
+        except Exception as e:
+            save_info.logger.info("Error for evolution %s: %s", i, e)
+            msg = f"Error during evolution {i}: {e}"
+            raise ValueError(msg) from e
+
+        entry, _ = _finalize_generation_step(
+            response=response,
+            code_language=code_language,
+            code=code,
+            is_context_length_overflow=is_context_length_overflow,
+            config=config,
+            model_config=model_config,
+            session=session,
+            public_cases=public_cases,
+            save_info=save_info,
+            filename=f"evolution_results_{i}.json",
+        )
+        entry["operation"] = operation
+        entry["parents"] = parents
+        _save_phase3_step(
+            step_name="Evolution",
+            i=i,
+            response=response,
+            entry=entry,
+            results=results_evolution,
+            results_filename=results_filename,
+            conversations_filename=f"evolution_conversations_{i}.json",
+            save_info=save_info,
+        )
+
+    return results_evolution
+
+
+def _load_budget_message_history(
+    save_info: SaveInfo,
+    index: int,
+    initial_message_history: list[ModelMessage],
+) -> list[ModelMessage]:
+    if index == 0:
+        return initial_message_history
+    return save_info.load_conversations(f"budget_conversations_{index}.json").all_messages()
+
+
+def _load_budget_public_result(
+    save_info: SaveInfo,
+    index: int,
+    initial_public_result: Result | None,
+    results: dict[int, dict[str, Any]],
+) -> Result | None:
+    if str(results[index].get("code", "")).strip() == "":
+        return None
+    if index == 0:
+        return initial_public_result
+    return save_info.load_ale_bench_results(f"budget_results_{index}.json")
+
+
+def run_budget_aware(
+    config: EvaluationConfig,
+    model_config: dict[str, Any],
+    session: Session,
+    initial_message_history: list[ModelMessage],
+    initial_public_result: Result | None,
+    initial_result: dict[str, Any],
+    save_info: SaveInfo,
+    llm_semaphore: BoundedSemaphore | None = None,
+) -> dict[int, dict[str, Any]]:
+    """Run a budget-aware strategy where the model chooses each step's action.
+
+    Each step first asks the model (a compact controller call) to choose between SAMPLE
+    (a fresh solution in a fresh context) and REFINE (continue improving the current best
+    solution), given the remaining budget and the attempt history. A context length overflow
+    on REFINE forces SAMPLE for the remaining steps; an overflow on SAMPLE stops the run.
+    """
+    public_cases = None
+    if config.n_public_cases is not None:
+        public_cases = session.case_gen(list(range(config.n_public_cases)))
+
+    results_filename = "budget_results.json"
+    results_budget = _load_phase3_results(save_info, results_filename, initial_result)
+    max_result_index = max(results_budget.keys())
+    last_entry = results_budget[max_result_index]
+    if last_entry["is_context_length_overflow"] and last_entry.get("action") == "sample":
+        save_info.logger.info(
+            "Already found a context length overflow on sample for budget %s, returning the results",
+            max_result_index,
+        )
+        return results_budget
+    initial_index = len(results_budget)
+    if initial_index >= config.n_self_refine:
+        if not (save_info.results / results_filename).exists():  # NOTE: n_self_refine=1
+            _run_with_retries(
+                "Budget summary save",
+                save_info,
+                lambda: save_info.save_results(results_filename, {str(k): v for k, v in results_budget.items()}),
+            )
+        save_info.logger.info("Skipping budget-aware strategy because already generated %s results", initial_index)
+        return results_budget
+
+    score_type = session.problem.metadata.score_type
+    force_sample = any(
+        entry.get("action") == "refine" and entry["is_context_length_overflow"] for entry in results_budget.values()
+    )
+    for i in range(initial_index, config.n_self_refine):
+        remaining_budget = config.n_self_refine - i
+        controller_response: AgentRunResult[str] | None = None
+        if force_sample:
+            action = "sample"
+            save_info.logger.info("Budget %s/%s: forcing sample after refine overflow", i + 1, config.n_self_refine)
+        else:
+            history_rows = [
+                (j, str(results_budget[j].get("action", "initial")), int(results_budget[j]["overall_absolute_score"]))
+                for j in sorted(results_budget)
+            ]
+            try:
+                controller_response = safe_generation(
+                    model_config=model_config,
+                    user_prompt=create_budget_action_message(config.prompt_args, remaining_budget, history_rows),
+                    system_prompt=create_system_message(config.prompt_args),
+                    timeout=TIMEOUT_SECONDS,
+                    num_retries=MAX_RETRIES,
+                    llm_semaphore=llm_semaphore,
+                )
+                action = parse_budget_action(controller_response.output)
+            except Exception as e:
+                save_info.logger.info("Budget controller failed at step %s: %s. Defaulting to refine", i, e)
+                action = "refine"
+            save_info.logger.info("Budget %s/%s: action=%s", i + 1, config.n_self_refine, action)
+
+        refined_from: int | None = None
+        is_context_length_overflow = False
+        response: AgentRunResult[str] | None = None
+        code_language = ""
+        code = ""
+        try:
+            if action == "sample":
+                response = safe_generation(
+                    model_config=model_config,
+                    user_prompt=create_initial_message(config.prompt_args, session.problem),
+                    system_prompt=create_system_message(config.prompt_args),
+                    timeout=TIMEOUT_SECONDS,
+                    num_retries=MAX_RETRIES,
+                    llm_semaphore=llm_semaphore,
+                )
+            else:
+                _, _, best_index = select_solution_from_self_refine(results_budget, score_type=score_type)
+                refined_from = best_index
+                best_public_result = _load_budget_public_result(
+                    save_info, best_index, initial_public_result, results_budget
+                )
+                response = safe_generation(
+                    model_config=model_config,
+                    user_prompt=_build_refinement_user_prompt(config, session, best_public_result, save_info),
+                    message_history=_load_budget_message_history(save_info, best_index, initial_message_history),
+                    timeout=TIMEOUT_SECONDS,
+                    num_retries=MAX_RETRIES,
+                    llm_semaphore=llm_semaphore,
+                )
+            code_language, code = get_code_from_response(
+                response.output,
+                config.prompt_args.code_language,
+                config.prompt_args.judge_version,
+            )
+        except MaxTokenError as e:
+            save_info.logger.info("Context length overflow for budget %s (%s): %s", i, action, e)
+            is_context_length_overflow = True
+            if action == "refine":
+                force_sample = True
+        except Exception as e:
+            save_info.logger.info("Error for budget %s: %s", i, e)
+            msg = f"Error during budget-aware step {i}: {e}"
+            raise ValueError(msg) from e
+
+        entry, _ = _finalize_generation_step(
+            response=response,
+            code_language=code_language,
+            code=code,
+            is_context_length_overflow=is_context_length_overflow,
+            config=config,
+            model_config=model_config,
+            session=session,
+            public_cases=public_cases,
+            save_info=save_info,
+            filename=f"budget_results_{i}.json",
+            extra_response=controller_response,
+        )
+        entry["action"] = action
+        entry["refined_from"] = refined_from
+        # NOTE: Keep all budget conversations because any past best may be refined later
+        _save_phase3_step(
+            step_name="Budget",
+            i=i,
+            response=response,
+            entry=entry,
+            results=results_budget,
+            results_filename=results_filename,
+            conversations_filename=f"budget_conversations_{i}.json",
+            save_info=save_info,
+        )
+
+        # End the run if even a fresh context overflows
+        if is_context_length_overflow and action == "sample":
+            save_info.logger.info("Context length overflow on sample for budget %s, stopping", i)
+            break
+
+    return results_budget

--- a/src/ale_bench_eval/selection.py
+++ b/src/ale_bench_eval/selection.py
@@ -1,8 +1,10 @@
+from collections.abc import Sequence
 from typing import Any, Literal, TypeGuard
 
 import numpy as np
 
 from ale_bench.data import ScoreType
+from ale_bench.result import CaseResult, JudgeResult
 from ale_bench_eval.language_config import ALL_CODE_LANGUAGES_SET, StoredCodeLanguage
 
 VALID_CODE_LANGUAGES = {"", "any", *ALL_CODE_LANGUAGES_SET}
@@ -29,6 +31,32 @@ def get_solution_info(target_result: dict[str, Any]) -> tuple[StoredCodeLanguage
 
 def get_worst_score(score_type: ScoreType) -> int:
     return -1 if score_type == ScoreType.MAXIMIZE else 1000000000000000000
+
+
+def select_worst_case_indices(
+    case_results: Sequence[CaseResult],
+    score_type: ScoreType,
+    k: int,
+) -> list[int]:
+    """Select the indices of the k worst cases; non-AC cases rank worse than any accepted case.
+
+    Args:
+        case_results: Per-case results to rank.
+        score_type: Score type (MINIMIZE or MAXIMIZE).
+        k: Number of indices to return.
+
+    Returns:
+        list of case indices ordered from worst to less bad.
+
+    """
+    sign = -1 if score_type == ScoreType.MAXIMIZE else 1
+
+    def badness(idx: int) -> tuple[int, int, int]:
+        case_result = case_results[idx]
+        is_accepted = case_result.judge_result == JudgeResult.ACCEPTED
+        return (int(is_accepted), -sign * case_result.absolute_score, idx)
+
+    return sorted(range(len(case_results)), key=badness)[:k]
 
 
 def select_solution_from_repeated_sampling(

--- a/tests/test_eval_strategies.py
+++ b/tests/test_eval_strategies.py
@@ -8,8 +8,14 @@ from pydantic_ai import BinaryContent
 from ale_bench.data import ScoreType
 from ale_bench.result import CaseResult, JudgeResult, ResourceUsage, Result
 from ale_bench_eval.data_types import EvaluationConfig
-from ale_bench_eval.prompts.builder import PromptArgs, create_feedback_message, diagnostic_feedback
-from ale_bench_eval.scaffolds import _build_refinement_user_prompt
+from ale_bench_eval.prompts.builder import (
+    PromptArgs,
+    create_budget_action_message,
+    create_feedback_message,
+    diagnostic_feedback,
+    parse_budget_action,
+)
+from ale_bench_eval.scaffolds import _build_refinement_user_prompt, _pick_crossover_parents, _truncate_population
 from ale_bench_eval.selection import select_worst_case_indices
 
 
@@ -184,3 +190,73 @@ def test_build_refinement_user_prompt_visualization_failure_degrades() -> None:
     result = make_result([make_case_result(100)])
     message = _build_refinement_user_prompt(config, session, result, MagicMock())
     assert all(not isinstance(content, BinaryContent) for content in message)
+
+
+def make_population_entry(score: int, code: str = "int main() {}") -> dict[str, int | str]:
+    return {"code": code, "overall_absolute_score": score}
+
+
+def test_truncate_population_orders_best_first_and_drops_empty_code() -> None:
+    entries = [
+        (("repeated_sampling", 0), make_population_entry(10)),
+        (("repeated_sampling", 1), make_population_entry(30)),
+        (("evolution", 1), make_population_entry(999, code="  ")),
+        (("evolution", 2), make_population_entry(20)),
+    ]
+    population = _truncate_population(entries, 2, ScoreType.MAXIMIZE)
+    assert [key for key, _ in population] == [("repeated_sampling", 1), ("evolution", 2)]
+    population = _truncate_population(entries, 2, ScoreType.MINIMIZE)
+    assert [key for key, _ in population] == [("repeated_sampling", 0), ("evolution", 2)]
+
+
+def test_truncate_population_is_deterministic_on_ties() -> None:
+    entries = [
+        (("repeated_sampling", 1), make_population_entry(10)),
+        (("evolution", 1), make_population_entry(10)),
+        (("repeated_sampling", 0), make_population_entry(10)),
+    ]
+    population = _truncate_population(entries, 3, ScoreType.MAXIMIZE)
+    assert [key for key, _ in population] == [
+        ("evolution", 1),
+        ("repeated_sampling", 0),
+        ("repeated_sampling", 1),
+    ]
+
+
+def test_pick_crossover_parents_is_score_diverse() -> None:
+    population = [
+        (("repeated_sampling", 0), make_population_entry(100)),
+        (("evolution", 1), make_population_entry(90)),
+        (("evolution", 2), make_population_entry(10)),
+    ]
+    best, partner = _pick_crossover_parents(population)
+    assert best[0] == ("repeated_sampling", 0)
+    assert partner[0] == ("evolution", 2)
+
+
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        pytest.param("ACTION: SAMPLE\nTrying a new idea.", "sample", id="sample"),
+        pytest.param("ACTION: REFINE\nKeep improving.", "refine", id="refine"),
+        pytest.param("action: sample", "sample", id="case_insensitive"),
+        pytest.param("I considered ACTION: SAMPLE but decided on\nACTION: REFINE", "refine", id="last_match_wins"),
+        pytest.param("Let me think about it...", "refine", id="unparseable_defaults_to_refine"),
+        pytest.param("", "refine", id="empty_defaults_to_refine"),
+    ],
+)
+def test_parse_budget_action(response: str, expected: str) -> None:
+    assert parse_budget_action(response) == expected
+
+
+def test_create_budget_action_message_contents() -> None:
+    message = create_budget_action_message(
+        make_prompt_args(),
+        remaining_budget=7,
+        history_rows=[(0, "initial", 100), (1, "sample", 120), (2, "refine", 130)],
+    )
+    assert "7 calls left" in message
+    assert "- Attempt 0 (initial): score=100" in message
+    assert "- Attempt 2 (refine): score=130" in message
+    assert "ACTION: SAMPLE" in message
+    assert "ACTION: REFINE" in message

--- a/tests/test_eval_strategies.py
+++ b/tests/test_eval_strategies.py
@@ -1,0 +1,186 @@
+from typing import Literal
+from unittest.mock import MagicMock
+
+import pytest
+from PIL import Image
+from pydantic_ai import BinaryContent
+
+from ale_bench.data import ScoreType
+from ale_bench.result import CaseResult, JudgeResult, ResourceUsage, Result
+from ale_bench_eval.data_types import EvaluationConfig
+from ale_bench_eval.prompts.builder import PromptArgs, create_feedback_message, diagnostic_feedback
+from ale_bench_eval.scaffolds import _build_refinement_user_prompt
+from ale_bench_eval.selection import select_worst_case_indices
+
+
+def make_case_result(
+    absolute_score: int,
+    judge_result: JudgeResult = JudgeResult.ACCEPTED,
+    input_str: str | None = "10 20\n0 1 2",
+    output_str: str | None = "3\n",
+) -> CaseResult:
+    return CaseResult(
+        input_str=input_str,
+        output_str=output_str,
+        judge_result=judge_result,
+        message="",
+        absolute_score=absolute_score,
+        execution_time=1.0,
+        memory_usage=1024 * 1024,
+    )
+
+
+def make_result(case_results: list[CaseResult]) -> Result:
+    return Result(allow_score_non_ac=True, resource_usage=ResourceUsage(), case_results=case_results)
+
+
+def make_prompt_args(prompt_language: Literal["en", "ja"] = "en") -> PromptArgs:
+    return PromptArgs(
+        code_language="cpp20",
+        judge_version="202301",
+        prompt_language=prompt_language,
+        use_image=False,
+    )
+
+
+def make_config(
+    *,
+    feedback_diagnostic: bool = False,
+    feedback_visualization: bool = False,
+    n_feedback_worst_cases: int = 3,
+) -> EvaluationConfig:
+    return EvaluationConfig(
+        model_name="test-model",
+        n_repeated_sampling=1,
+        n_self_refine=1,
+        num_workers=1,
+        reuse_containers=False,
+        n_public_cases=None,
+        prompt_args=make_prompt_args(),
+        problem_id="ahc001",
+        lite_version=True,
+        feedback_diagnostic=feedback_diagnostic,
+        feedback_visualization=feedback_visualization,
+        n_feedback_worst_cases=n_feedback_worst_cases,
+    )
+
+
+@pytest.mark.parametrize(
+    ("scores", "score_type", "k", "expected"),
+    [
+        pytest.param([10, 30, 20], ScoreType.MAXIMIZE, 2, [0, 2], id="maximize_lowest_first"),
+        pytest.param([10, 30, 20], ScoreType.MINIMIZE, 2, [1, 2], id="minimize_highest_first"),
+        pytest.param([10, 30, 20], ScoreType.MAXIMIZE, 10, [0, 2, 1], id="k_exceeds_length"),
+        pytest.param([5, 5, 5], ScoreType.MAXIMIZE, 2, [0, 1], id="ties_prefer_lower_index"),
+    ],
+)
+def test_select_worst_case_indices(scores: list[int], score_type: ScoreType, k: int, expected: list[int]) -> None:
+    case_results = [make_case_result(score) for score in scores]
+    assert select_worst_case_indices(case_results, score_type, k) == expected
+
+
+def test_select_worst_case_indices_non_ac_ranks_worst() -> None:
+    case_results = [
+        make_case_result(1, judge_result=JudgeResult.ACCEPTED),
+        make_case_result(1000, judge_result=JudgeResult.TIME_LIMIT_EXCEEDED),
+        make_case_result(2, judge_result=JudgeResult.ACCEPTED),
+    ]
+    assert select_worst_case_indices(case_results, ScoreType.MAXIMIZE, 2) == [1, 0]
+
+
+@pytest.mark.parametrize("prompt_language", ["en", "ja"])
+def test_diagnostic_feedback_contents(prompt_language: Literal["en", "ja"]) -> None:
+    result = make_result(
+        [
+            make_case_result(100, input_str="7 3\nrest"),
+            make_case_result(5, input_str=None),
+            make_case_result(50, judge_result=JudgeResult.WRONG_ANSWER),
+        ]
+    )
+    feedback = diagnostic_feedback(make_prompt_args(prompt_language), result, worst_indices=[1, 2])
+    assert 'Case 1: params="7 3", score=100' in feedback
+    assert 'Case 2: params="N/A", score=5 (WORST)' in feedback
+    assert 'Case 3: params="10 20", score=50, judge=WRONG_ANSWER (WORST)' in feedback
+    assert "score=100 (WORST)" not in feedback  # Case 1 is not marked as worst
+
+
+def test_create_feedback_message_backward_compatible() -> None:
+    args = make_prompt_args()
+    result = make_result([make_case_result(100)])
+    message = create_feedback_message(args, result)
+    assert len(message) == 1
+    assert isinstance(message[0], str)
+    assert "Overall absolute score: 100" in message[0]
+    # No result available (e.g. no code block found in the response)
+    no_result_message = create_feedback_message(args, None)
+    assert len(no_result_message) == 1
+    assert isinstance(no_result_message[0], str)
+    assert "No public result is available" in no_result_message[0]
+
+
+def test_create_feedback_message_with_diagnostic_and_visualizations() -> None:
+    args = make_prompt_args()
+    result = make_result([make_case_result(100)])
+    image = BinaryContent(data=b"fake-png", media_type="image/png")
+    message = create_feedback_message(
+        args,
+        result,
+        diagnostic="\n[Per-case diagnostics]\ncase table",
+        visualizations=[image],
+        visualized_case_indices=[0],
+    )
+    assert len(message) == 3
+    assert isinstance(message[0], str)
+    assert "[Per-case diagnostics]" in message[0]
+    assert "worst-scoring cases: 1" in message[0]
+    assert message[1] is image
+    assert isinstance(message[2], str)
+
+
+def make_mock_session(problem_id: str, score_type: ScoreType = ScoreType.MAXIMIZE) -> MagicMock:
+    session = MagicMock()
+    session.problem.metadata.problem_id = problem_id
+    session.problem.metadata.score_type = score_type
+    return session
+
+
+def test_build_refinement_user_prompt_defaults_to_plain_feedback() -> None:
+    config = make_config()
+    session = make_mock_session("ahc001")
+    result = make_result([make_case_result(100)])
+    message = _build_refinement_user_prompt(config, session, result, MagicMock())
+    assert message == create_feedback_message(config.prompt_args, result)
+    session.local_visualization.assert_not_called()
+
+
+def test_build_refinement_user_prompt_skips_visualization_for_no_local_vis() -> None:
+    config = make_config(feedback_visualization=True)
+    session = make_mock_session("ahc016")
+    result = make_result([make_case_result(100)])
+    message = _build_refinement_user_prompt(config, session, result, MagicMock())
+    session.local_visualization.assert_not_called()
+    assert all(not isinstance(content, BinaryContent) for content in message)
+
+
+def test_build_refinement_user_prompt_renders_and_drops_none_images() -> None:
+    config = make_config(feedback_visualization=True, n_feedback_worst_cases=2)
+    session = make_mock_session("ahc001")
+    session.local_visualization.return_value = [None, Image.new("RGB", (4, 4))]
+    result = make_result([make_case_result(10), make_case_result(20), make_case_result(30)])
+    message = _build_refinement_user_prompt(config, session, result, MagicMock())
+    (called_inputs, called_outputs), _ = session.local_visualization.call_args
+    assert len(called_inputs) == len(called_outputs) == 2
+    images = [content for content in message if isinstance(content, BinaryContent)]
+    assert len(images) == 1
+    # The surviving image belongs to case index 1 (the second-worst case)
+    assert isinstance(message[0], str)
+    assert "worst-scoring cases: 2" in message[0]
+
+
+def test_build_refinement_user_prompt_visualization_failure_degrades() -> None:
+    config = make_config(feedback_visualization=True)
+    session = make_mock_session("ahc001")
+    session.local_visualization.side_effect = RuntimeError("docker down")
+    result = make_result([make_case_result(100)])
+    message = _build_refinement_user_prompt(config, session, result, MagicMock())
+    assert all(not isinstance(content, BinaryContent) for content in message)


### PR DESCRIPTION
## Summary

Two new phase-3 strategies for `ale_bench_eval`, selectable via `--strategy` (default `self_refine` keeps current behavior exactly). Both improve exploration beyond linear self-refinement while staying call-count-matched: entry 0 is the selected repeated sampling result and the strategy generates the same number of solutions as self-refinement at equal `(n_repeated_sampling, n_self_refine)`.

- `--strategy evolution`: keeps a population seeded by the repeated sampling results. Each iteration generates one child via LLM mutation (improve one parent with its feedback) or crossover (prompt the model to combine two score-diverse parents), evaluates it, and truncates the population by score. Parameters: `--evolution_population_size` (4), `--evolution_crossover_prob` (0.3), `--evolution_seed` (0).
- `--strategy budget`: each step a compact controller call chooses between `SAMPLE` (fresh solution, fresh context) and `REFINE` (continue the current best solution's conversation), given the remaining budget and the attempt history. Controller tokens are accounted into the step's entry, so cost estimation stays correct.

## Design notes

- **Deterministic resume for evolution**: operator and parent choices derive from `random.Random(evolution_seed * 1_000_003 + i)`, so reloading the saved results replays the run exactly.
- **Overflow handling for budget**: a context length overflow on REFINE forces SAMPLE for the remaining steps (a fresh context sidesteps the overflow); an overflow on SAMPLE stops the run. Budget conversations are all retained because any past best may be refined later.
- REFINE composes with the feedback enrichment flags from #39.
- Phase 4 selection, power-of-two evaluation points, cost estimation, and aggregation reuse the existing machinery under the strategy's method name (`evolution_1`, `budget_2`, ...), so downstream tables work unchanged.
- New settings are written to `experiment_settings.json` and checked on resume with backward-compatible defaults.

Depends on #39 (branched from it; the first two commits are shared).

## Testing

- Extends `tests/test_eval_strategies.py` (no Docker or API keys): population truncation for both score types with empty-code exclusion and deterministic tie-breaking, score-diverse crossover pairing, budget action parsing (case-insensitivity, last-match-wins, refine fallback), and controller message contents.
- `ruff check`, `ruff format --check`, `ty check`, and `pytest -m "not docker"` (709 passed) are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)